### PR TITLE
Remove deprecated parts of chisel to get rid of warnings

### DIFF
--- a/chisel/accio/src/main/scala/AccOut.scala
+++ b/chisel/accio/src/main/scala/AccOut.scala
@@ -20,7 +20,7 @@ class AccOut ()(implicit params : AccParams) extends Module with AccioDebug {
   val remainReqCnt = RegInit(init=0.U)
   val nextReqAddr = RegInit(init=0.U)
   
-  val w_hasReq = Wire(init = (remainReqCnt != 0.U)) 
+  val w_hasReq = WireInit(remainReqCnt =/= 0.U)
   
   io.acc_req_in.nodeq()
   io.acc_data_in.nodeq()
@@ -28,11 +28,11 @@ class AccOut ()(implicit params : AccParams) extends Module with AccioDebug {
   io.mem_out.noenq()
 
   
-  val w_canGetNextReq = Wire(init = (remainReqCnt === 0.U))   
+  val w_canGetNextReq = WireInit(remainReqCnt === 0.U)
   
-  val w_wr_data = Wire(init = io.acc_data_in.bits)
+  val w_wr_data = WireInit(io.acc_data_in.bits)
 
-  when(remainReqCnt != 0.U) {
+  when(remainReqCnt =/= 0.U) {
     when (io.mem_out.ready) {
       io.acc_data_in.deq
     }

--- a/chisel/accio/src/main/scala/AccioTypes.scala
+++ b/chisel/accio/src/main/scala/AccioTypes.scala
@@ -351,7 +351,7 @@ object CacheLine {
   def numCLsFor[T<:Data](gen: T, size: UInt)(implicit params: AccParams) = {
     if(gen.getWidth <= params.CacheLineWidth && params.CacheLineWidth%gen.getWidth == 0) {
       val rem = size % (params.CacheLineWidth/gen.getWidth).U
-      size / (params.CacheLineWidth/gen.getWidth).U + Mux(rem != 0.U,1.U,0.U) 
+      size / (params.CacheLineWidth/gen.getWidth).U + Mux(rem =/= 0.U,1.U,0.U)
     } else {
       assert(false, "Not supported")
       size

--- a/chisel/accio/src/main/scala/MemArbiter.scala
+++ b/chisel/accio/src/main/scala/MemArbiter.scala
@@ -17,7 +17,7 @@ class MemSteerReged[T<:Data with HasMetadata]( gen : T, ways: Int, steerBit : In
   })
   
   val stage_out_N = Array.fill(ways)(Module(new DecoupledStage( gen )))
-  val out_stage_inps = Vec(stage_out_N.map(_.io.inp))
+  val out_stage_inps = VecInit(stage_out_N.map(_.io.inp))
   for (i <- 0 until ways) {
     stage_out_N(i).io.inp  <> out_stage_inps(i)
   }
@@ -37,7 +37,7 @@ class MemSteerReged[T<:Data with HasMetadata]( gen : T, ways: Int, steerBit : In
   val pendAuId = pendData.tag(steerBit+log2Ceil(ways)-1, steerBit)
 
 
-  val pendCopy = Wire(init = pendData)
+  val pendCopy = WireInit(init = pendData)
   pendCopy.tag := UIntUtils.replace(pendData.tag, steerBit, 0.U(log2Ceil(ways).W))
 
   //printf("In data %x %x\n", pendData.asUInt(), pendCopy.asUInt())
@@ -51,7 +51,7 @@ class MemSteerReged[T<:Data with HasMetadata]( gen : T, ways: Int, steerBit : In
   when (pendValid && out_stage_inps(pendAuId).ready || !pendValid) {
     pendValid := io.qin.valid
     when (io.qin.valid) {
-      pendData := Wire(init = io.qin.deq())
+      pendData := WireInit(init = io.qin.deq())
     }
   }
 
@@ -62,7 +62,7 @@ class MemSteerReged[T<:Data with HasMetadata]( gen : T, ways: Int, steerBit : In
 
 class RRArbiterWithTag [T<:Data with HasMetadata](gen : T, ways: Int, steerBit : Int) extends RRArbiter(gen, ways) {
   
-  val data = Wire(init = io.in(io.chosen).bits)
+  val data = WireInit(init = io.in(io.chosen).bits)
   when (io.out.valid) {
     data.tag := UIntUtils.replace(io.in(io.chosen).bits.tag, steerBit, io.chosen.asTypeOf(ways.U))
   }
@@ -164,4 +164,3 @@ object WriteMemArbiter  {
     (wrArb.io.req_out,wrArb.io.resp_in) 
   }
 }
-

--- a/chisel/accio/src/main/scala/MockMemory.scala
+++ b/chisel/accio/src/main/scala/MockMemory.scala
@@ -51,11 +51,11 @@ class MockMemoryComb (clSize : Int = 128, mem_init_function: Option[UInt => UInt
     val out_p = cnt.value 
     
     //io.mem_rd_in.ready := io.mem_rd_out.ready
-    //io.mem_rd_in.ready := Wire(init = !io.mem_rd_in.valid || io.mem_rd_out.ready)
-    //io.mem_wr_in.ready := Wire(init = !io.mem_wr_in.valid ||  !(cnt.value % 4.U) && io.mem_wr_out.ready)
+    //io.mem_rd_in.ready := WireInit(init = !io.mem_rd_in.valid || io.mem_rd_out.ready)
+    //io.mem_wr_in.ready := WireInit(init = !io.mem_wr_in.valid ||  !(cnt.value % 4.U) && io.mem_wr_out.ready)
   
     when (!testPushBack.B || !(cnt.value % 3.U)) {
-      val w_mem_rd_req = Wire(init = io.mem_rd_in.bits)
+      val w_mem_rd_req = WireInit(init = io.mem_rd_in.bits)
       when (io.mem_rd_out.ready) {
         w_mem_rd_req := io.mem_rd_in.deq     //just setting ready to true (bits were taken before)
       }
@@ -66,7 +66,7 @@ class MockMemoryComb (clSize : Int = 128, mem_init_function: Option[UInt => UInt
     }
     
     when (!testPushBack.B || !(cnt.value % 4.U)) {
-      val w_mem_wr_in = Wire(init = io.mem_wr_in.bits)
+      val w_mem_wr_in = WireInit(init = io.mem_wr_in.bits)
       when (io.mem_wr_out.ready) {
         w_mem_wr_in := io.mem_wr_in.deq
       }

--- a/chisel/accio/src/main/scala/TypeRepacker.scala
+++ b/chisel/accio/src/main/scala/TypeRepacker.scala
@@ -52,7 +52,7 @@ class TypeRepacker[T1 <: Data, T2<: Data] (gen1 : T1, gen2 : T2) extends Module 
       val outData = inAsT2(ratio.U - remainNum)
       remainNum := remainNum - 1.U 
       
-      io.out.enq(outData.asUInt.asTypeOf(io.out.bits))
+      io.out.enq(outData.asTypeOf(io.out.bits))
       // last output, can read a new input
       when (remainNum === 1.U) {
         w_finish := true.B

--- a/chisel/accio/src/main/scala/TypeRepacker.scala
+++ b/chisel/accio/src/main/scala/TypeRepacker.scala
@@ -47,12 +47,12 @@ class TypeRepacker[T1 <: Data, T2<: Data] (gen1 : T1, gen2 : T2) extends Module 
     io.in.nodeq()
     io.out.noenq()
     
-    val w_finish = Wire(init = (remainNum === 0.U)) 
+    val w_finish = WireInit(init = (remainNum === 0.U))
     when (io.out.ready && remainNum > 0.U) {
       val outData = inAsT2(ratio.U - remainNum)
       remainNum := remainNum - 1.U 
       
-      io.out.enq(io.out.bits.fromBits(outData.asUInt))
+      io.out.enq(outData.asUInt.asTypeOf(io.out.bits))
       // last output, can read a new input
       when (remainNum === 1.U) {
         w_finish := true.B
@@ -60,7 +60,7 @@ class TypeRepacker[T1 <: Data, T2<: Data] (gen1 : T1, gen2 : T2) extends Module 
     }
     
     when (io.in.valid && w_finish) {
-      inAsT2 := inAsT2.fromBits(io.in.deq.asUInt)
+      inAsT2 := io.in.deq.asUInt.asTypeOf(inAsT2)
       remainNum := ratio.U
     }
     //printf("io.in.valid = %d io.in.bits.asUInt()=%d, remainNum = %d inAsT2(0) = %d io.out(0) = %d\n", io.in.valid, io.in.bits.asUInt(), remainNum, inAsT2(0), io.out.bits(0).asUInt())
@@ -73,21 +73,21 @@ class TypeRepacker[T1 <: Data, T2<: Data] (gen1 : T1, gen2 : T2) extends Module 
     
     val outAsT1 = Reg(Vec(ratio,UInt(in1width.W)))
     val remainNum = RegInit(ratio.U.cloneType, init = 0.U)     
-    val w_remainNum = Wire(ratio.U.cloneType, init = remainNum) 
+    val w_remainNum = WireInit(ratio.U.cloneType, init = remainNum)
 
     io.in.nodeq()
     io.out.noenq()
 
-    when (io.out.ready && (remainNum === ratio.U || (remainNum != 0.U && io.flush))) {
-      io.out.enq(io.out.bits.fromBits(outAsT1.asUInt))
+    when (io.out.ready && (remainNum === ratio.U || (remainNum =/= 0.U && io.flush))) {
+      io.out.enq(outAsT1.asUInt.asTypeOf(io.out.bits))
       io.cnt := remainNum
       // last input, can push output and get a new input
       w_remainNum := 0.U
     }
 
-    when (io.in.valid && w_remainNum != ratio.U) {
+    when (io.in.valid && w_remainNum =/= ratio.U) {
       val inData = io.in.deq
-      outAsT1(w_remainNum) := outAsT1(w_remainNum).fromBits(inData.asUInt())
+      outAsT1(w_remainNum) := inData.asUInt.asTypeOf(outAsT1(w_remainNum))
       remainNum := w_remainNum + 1.U
     }.otherwise {
       remainNum := w_remainNum
@@ -104,7 +104,7 @@ object TypeRepacker {
     tr.io.in.valid := in.valid 
     tr.io.in.bits := in.bits
     in.ready := tr.io.in.ready
-    tr.io.flush := Wire(init=false.B)
+    tr.io.flush := WireInit(init=false.B)
     if (moore) 
       MooreStage(tr.io.out)
     else 
@@ -117,7 +117,7 @@ object TypeRepacker {
     tr.io.in.valid := in.valid 
     tr.io.in.bits := in.bits
     in.ready := tr.io.in.ready
-    tr.io.flush := Wire(init=flush)
+    tr.io.flush := WireInit(init=flush)
     val out = Wire(Decoupled(to))
     out.valid := tr.io.out.valid
     tr.io.out.ready := out.ready
@@ -134,7 +134,7 @@ object TypeRepackerComb {
     tr.io.in.valid := in.valid // not using <> so that override is allowed
     tr.io.in.bits := in.bits
     in.ready := tr.io.in.ready
-    tr.io.flush := Wire(init=false.B)
+    tr.io.flush := WireInit(init=false.B)
     tr.io.out
   }
   def apply[T1 <: Data, T2 <: Data with PackedWithCount] (in: DecoupledIO[T1], to: T2, flush: Bool): DecoupledIO[T2]  = {
@@ -142,7 +142,7 @@ object TypeRepackerComb {
     tr.io.in.valid := in.valid // not using <> so that override is allowed
     tr.io.in.bits := in.bits
     in.ready := tr.io.in.ready
-    tr.io.flush := Wire(init=flush)
+    tr.io.flush := WireInit(init=flush)
     val out = Wire(Decoupled(to))
     out.valid := tr.io.out.valid
     tr.io.out.ready := out.ready
@@ -172,11 +172,11 @@ class TypeRepackerVec[T1 <: Data, T2<: Data] (gen1 : T1, rate1 : Int, gen2 : T2,
 
   tr.io.in.valid <> io.in.valid
   tr.io.in.ready <> io.in.ready
-  tr.io.in.bits := tr.io.in.bits.fromBits(io.in.bits.asUInt())
+  tr.io.in.bits := io.in.bits.asUInt.asTypeOf(tr.io.in.bits)
   
   io.out.valid <> tr.io.out.valid
   io.out.ready <> tr.io.out.ready
-  io.out.bits := io.out.bits.fromBits(tr.io.out.bits.asUInt())
+  io.out.bits := tr.io.out.bits.asUInt.asTypeOf(io.out.bits)
 }
 
 class TypeRepackerVecReg[T1 <: Data, T2<: Data] (gen1 : T1, rate1 : Int, gen2 : T2, rate2 : Int) extends Module {

--- a/chisel/accio/src/test/scala/AccInTester.scala
+++ b/chisel/accio/src/test/scala/AccInTester.scala
@@ -205,7 +205,7 @@ class Top (bufSize: Int) extends Module {
   accIn.io.acc_out.valid <> io.acc_out.valid
   accIn.io.acc_out.ready <> io.acc_out.ready
   
-  accIn.io.acc_in.bits :=  accIn.io.acc_in.bits.fromBits(io.acc_in.bits) 
+  accIn.io.acc_in.bits := io.acc_in.bits.asTypeOf(accIn.io.acc_in.bits)
   io.acc_out.bits := accIn.io.acc_out.bits.asUInt
    
 }
@@ -331,5 +331,3 @@ class AccUserInTester extends ChiselFlatSpec {
 //  }
 
 }
-
-

--- a/chisel/accio/src/test/scala/AccOutTester.scala
+++ b/chisel/accio/src/test/scala/AccOutTester.scala
@@ -55,8 +55,8 @@ class TopAccOut extends Module {
   AccOut.io.acc_data_in.valid <> io.acc_data_in.valid
   AccOut.io.acc_data_in.ready <> io.acc_data_in.ready
   
-  AccOut.io.acc_req_in.bits :=  AccOut.io.acc_req_in.bits.fromBits(io.acc_req_in.bits) 
-  AccOut.io.acc_data_in.bits := AccOut.io.acc_data_in.bits.fromBits(io.acc_data_in.bits) 
+  AccOut.io.acc_req_in.bits :=  io.acc_req_in.bits.asTypeOf(AccOut.io.acc_req_in.bits)
+  AccOut.io.acc_data_in.bits := io.acc_data_in.bits.asTypeOf(AccOut.io.acc_data_in.bits)
   
   //printf("acc data in (v/r) %d/%d  data - %x - widths %d\n", io.acc_data_in.valid,io.acc_data_in.ready,io.acc_data_in.bits, io.acc_data_in.bits.getWidth.U)
    

--- a/chisel/accio/src/test/scala/TypeRepackerTester.scala
+++ b/chisel/accio/src/test/scala/TypeRepackerTester.scala
@@ -20,7 +20,7 @@ class BitsToVec[T <: Data](gen : T, N : Int) extends Module {
   val WIDTH = gen.getWidth
   
   for (i <- 0 until N){
-    io.out.bits(i) := io.out.bits(i).fromBits(io.in.bits(i*WIDTH+WIDTH-1,i*WIDTH))
+    io.out.bits(i) := io.in.bits(i*WIDTH+WIDTH-1,i*WIDTH).asTypeOf(io.out.bits(i))
   }
   
   //printf("BitsToVec %d converted to %d (valid=%d, %d) ready = %d\n", io.in.bits(0).asUInt, io.out.bits(0).asUInt, io.in.valid, io.out.valid, io.out.ready)
@@ -73,11 +73,11 @@ class TopSimple[T1 <: Data, T2<: Data] (gen1 : T1, gen2 : T2) extends TopIf(gen1
 
   dut.io.in.valid := io.in_flat.valid
   dut.io.in.ready <> io.in_flat.ready
-  dut.io.in.bits := dut.io.in.bits.fromBits(io.in_flat.bits.asUInt())
+  dut.io.in.bits := io.in_flat.bits.asUInt.asTypeOf(dut.io.in.bits)
   
   io.out_flat.valid := dut.io.out.valid 
   io.out_flat.ready <> dut.io.out.ready 
-  io.out_flat.bits := io.out_flat.bits.fromBits(dut.io.out.bits.asUInt()) 
+  io.out_flat.bits := dut.io.out.bits.asUInt.asTypeOf(io.out_flat.bits)
 }
 
 

--- a/chisel/dataflow_building_blocks/src/main/scala/SDFActor.scala
+++ b/chisel/dataflow_building_blocks/src/main/scala/SDFActor.scala
@@ -19,7 +19,7 @@ class FillableQueue [T <: Data] (gen: T, entries: Int, init_entries : Int, pipe:
   val fillStage = RegInit(init = init_entries.U) 
 
   
-  when (fillStage != 0.U) {
+  when (fillStage =/= 0.U) {
     fillStage := fillStage - 1.U
   }
 
@@ -28,7 +28,7 @@ class FillableQueue [T <: Data] (gen: T, entries: Int, init_entries : Int, pipe:
   io.count <> q.io.count
   
   io.enq.ready := Mux (fillStage === 0.U, q.io.enq.ready, false.B)
-  io.fenq.ready := Mux (fillStage != 0.U, q.io.enq.ready, false.B)
+  io.fenq.ready := Mux (fillStage =/= 0.U, q.io.enq.ready, false.B)
   
   q.io.enq.valid := Mux (fillStage === 0.U, io.enq.valid, io.fenq.valid)
   q.io.enq.bits := Mux (fillStage === 0.U, io.enq.bits, io.fenq.bits)

--- a/chisel/dataflow_building_blocks/src/main/scala/VectorAdd.scala
+++ b/chisel/dataflow_building_blocks/src/main/scala/VectorAdd.scala
@@ -26,7 +26,7 @@ class VectorAdd[T <: UInt] (gen : T, vecSize : Int) extends SDFActor(1, 1) {
   })
     
   override def func = {
-    val add = VecInit.tabulate(vecSize) {i => io.in.bits(i%vecSize) + io.in.bits(vecSize + i%vecSize) }
+    val add = VecInit(Seq.tabulate(vecSize) {i => io.in.bits(i%vecSize) + io.in.bits(vecSize + i%vecSize) })
     io.out.bits := add
     printf("VectorAdd IN = "); io.in.bits.foreach {printf("%d ", _)}; printf("\n")
     printf("VectorAdd OUT = ");add.foreach {printf("%d ", _)};printf("\n")
@@ -43,7 +43,7 @@ class VectorAdd2[T <: UInt] (gen : T, vecSize : Int) extends SDFActor(2,1) {
     })
     
     override def func = {
-      io.out.bits := VecInit.tabulate(vecSize) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit(Seq.tabulate(vecSize) {i => io.in1.bits(i) + io.in2.bits(i) })
     }
 }
 
@@ -123,7 +123,7 @@ class VecAddNoConfig[T <: UInt](gen : T, vecLen : Int)(implicit params : AccPara
     })
     
     override def func = {
-      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit(Seq.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) })
     }
   })
   val accin1 = Module (new AccIn(32))
@@ -154,13 +154,13 @@ class VecAddMulDP[T <: UInt](gen : T, vecLen : Int)(implicit params : AccParams)
     })
     
     override def func = {
-      val add = VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
-      val mul1 = VecInit.tabulate(vecLen) {i => io.in1.bits(i) * add(i) }
-      val mul2 = VecInit.tabulate(vecLen) {i => io.in2.bits(i) * add(i) }
-      val add2 = VecInit.tabulate(vecLen) {i => mul1(i) + mul2(i) }
-      val mul3 = VecInit.tabulate(vecLen) {i => mul1(i) * add2(i) }
-      val mul4 = VecInit.tabulate(vecLen) {i => mul2(i) * add2(i) }
-      val add3 = VecInit.tabulate(vecLen) {i => mul3(i) + mul4(i) }
+      val add = VecInit(Seq.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) })
+      val mul1 = VecInit(Seq.tabulate(vecLen) {i => io.in1.bits(i) * add(i) })
+      val mul2 = VecInit(Seq.tabulate(vecLen) {i => io.in2.bits(i) * add(i) })
+      val add2 = VecInit(Seq.tabulate(vecLen) {i => mul1(i) + mul2(i) })
+      val mul3 = VecInit(Seq.tabulate(vecLen) {i => mul1(i) * add2(i) })
+      val mul4 = VecInit(Seq.tabulate(vecLen) {i => mul2(i) * add2(i) })
+      val add3 = VecInit(Seq.tabulate(vecLen) {i => mul3(i) + mul4(i) })
       io.out.bits := add3
     }
 }
@@ -221,7 +221,7 @@ class VecAddNoConfigPpt[T <: UInt](val gen : T, val vecLen : Int)(implicit param
       val out = Out(Vec(vecLen, gen), 1) 
     })
     override def func = {
-      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit(Seq.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) })
     }
   })
   val accin1 = Module (new AccIn(32))

--- a/chisel/dataflow_building_blocks/src/main/scala/VectorAdd.scala
+++ b/chisel/dataflow_building_blocks/src/main/scala/VectorAdd.scala
@@ -26,7 +26,7 @@ class VectorAdd[T <: UInt] (gen : T, vecSize : Int) extends SDFActor(1, 1) {
   })
     
   override def func = {
-    val add = Vec.tabulate(vecSize) {i => io.in.bits(i%vecSize) + io.in.bits(vecSize + i%vecSize) }
+    val add = VecInit.tabulate(vecSize) {i => io.in.bits(i%vecSize) + io.in.bits(vecSize + i%vecSize) }
     io.out.bits := add
     printf("VectorAdd IN = "); io.in.bits.foreach {printf("%d ", _)}; printf("\n")
     printf("VectorAdd OUT = ");add.foreach {printf("%d ", _)};printf("\n")
@@ -43,7 +43,7 @@ class VectorAdd2[T <: UInt] (gen : T, vecSize : Int) extends SDFActor(2,1) {
     })
     
     override def func = {
-      io.out.bits := Vec.tabulate(vecSize) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit.tabulate(vecSize) {i => io.in1.bits(i) + io.in2.bits(i) }
     }
 }
 
@@ -123,7 +123,7 @@ class VecAddNoConfig[T <: UInt](gen : T, vecLen : Int)(implicit params : AccPara
     })
     
     override def func = {
-      io.out.bits := Vec.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
     }
   })
   val accin1 = Module (new AccIn(32))
@@ -154,13 +154,13 @@ class VecAddMulDP[T <: UInt](gen : T, vecLen : Int)(implicit params : AccParams)
     })
     
     override def func = {
-      val add = Vec.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
-      val mul1 = Vec.tabulate(vecLen) {i => io.in1.bits(i) * add(i) }
-      val mul2 = Vec.tabulate(vecLen) {i => io.in2.bits(i) * add(i) }
-      val add2 = Vec.tabulate(vecLen) {i => mul1(i) + mul2(i) }
-      val mul3 = Vec.tabulate(vecLen) {i => mul1(i) * add2(i) }
-      val mul4 = Vec.tabulate(vecLen) {i => mul2(i) * add2(i) }
-      val add3 = Vec.tabulate(vecLen) {i => mul3(i) + mul4(i) }
+      val add = VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      val mul1 = VecInit.tabulate(vecLen) {i => io.in1.bits(i) * add(i) }
+      val mul2 = VecInit.tabulate(vecLen) {i => io.in2.bits(i) * add(i) }
+      val add2 = VecInit.tabulate(vecLen) {i => mul1(i) + mul2(i) }
+      val mul3 = VecInit.tabulate(vecLen) {i => mul1(i) * add2(i) }
+      val mul4 = VecInit.tabulate(vecLen) {i => mul2(i) * add2(i) }
+      val add3 = VecInit.tabulate(vecLen) {i => mul3(i) + mul4(i) }
       io.out.bits := add3
     }
 }
@@ -221,7 +221,7 @@ class VecAddNoConfigPpt[T <: UInt](val gen : T, val vecLen : Int)(implicit param
       val out = Out(Vec(vecLen, gen), 1) 
     })
     override def func = {
-      io.out.bits := Vec.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
     }
   })
   val accin1 = Module (new AccIn(32))

--- a/chisel/dataflow_building_blocks/src/test/scala/PipeSquashTest.scala
+++ b/chisel/dataflow_building_blocks/src/test/scala/PipeSquashTest.scala
@@ -29,8 +29,8 @@ class PipeWithSquash(gen : UInt) extends PipeWithSquashIO(gen) {
   io.out.noenq
   io.in.nodeq
   
-  val w_stage2ready = Wire(init = !stage2.valid)
-  val w_stage1ready = Wire(init = !stage1.valid)
+  val w_stage2ready = WireInit(init = !stage2.valid)
+  val w_stage1ready = WireInit(init = !stage1.valid)
   
   //we use anti-dependency coding style to model pipeline 
   
@@ -69,8 +69,8 @@ class PipeWithSquashSimple(gen : UInt) extends PipeWithSquashIO(gen) {
   io.out.noenq
   io.in.nodeq
   
-  val w_stage2ready = Wire(init = !stage2.valid)
-  val w_stage1ready = Wire(init = !stage1.valid)
+  val w_stage2ready = WireInit(init = !stage2.valid)
+  val w_stage1ready = WireInit(init = !stage1.valid)
   
   //we use anti-dependency coding style to model pipeline 
   

--- a/chisel/dataflow_building_blocks/src/test/scala/SDFActorTest.scala
+++ b/chisel/dataflow_building_blocks/src/test/scala/SDFActorTest.scala
@@ -50,7 +50,7 @@ class TopSdf() extends Module {
   q1.io.fenq.valid <> io.in.valid
   io.in.ready <> q1.io.fenq.ready
   
-  q1.io.fenq.bits := q1.io.fenq.bits.fromBits(io.in.bits)
+  q1.io.fenq.bits := io.in.bits.asTypeOf(q1.io.fenq.bits)
 }
 
 

--- a/chisel/dataflow_building_blocks/src/test/scala/VectorAddTest.scala
+++ b/chisel/dataflow_building_blocks/src/test/scala/VectorAddTest.scala
@@ -48,7 +48,7 @@ class VecAddTb[T <: UInt](gen : T, vecSize : Int)(implicit params : AccParams) e
   mem.io.mem_wr_in <> va.io.mem_wr_req 
   mem.io.mem_wr_out <> va.io.mem_wr_resp 
   
-  va.io.config.bits := io.config.asUInt.asTypeOf(va.io.config.bits)
+  va.io.config.bits := io.config.asTypeOf(va.io.config.bits)
   va.io.config.valid <> io.config.valid
   va.io.config.ready <> io.config.ready
   

--- a/chisel/dataflow_building_blocks/src/test/scala/VectorAddTest.scala
+++ b/chisel/dataflow_building_blocks/src/test/scala/VectorAddTest.scala
@@ -48,7 +48,7 @@ class VecAddTb[T <: UInt](gen : T, vecSize : Int)(implicit params : AccParams) e
   mem.io.mem_wr_in <> va.io.mem_wr_req 
   mem.io.mem_wr_out <> va.io.mem_wr_resp 
   
-  va.io.config.bits := va.io.config.bits.fromBits(io.config.asUInt())  
+  va.io.config.bits := io.config.asUInt.asTypeOf(va.io.config.bits)
   va.io.config.valid <> io.config.valid
   va.io.config.ready <> io.config.ready
   

--- a/chisel/designutils/src/main/scala/DecoupledStage.scala
+++ b/chisel/designutils/src/main/scala/DecoupledStage.scala
@@ -39,7 +39,7 @@ object DecoupledStageInv {
   def apply[T <: Data](enq: DecoupledIO[T]): DecoupledIO[T]  = {
     val q = Module(new DecoupledStage(enq.bits.cloneType))
     q.io.inp.valid := enq.valid // not using <> so that override is allowed
-    q.io.inp.bits := (~enq.bits.asUInt).asTypeOf(q.io.inp.bits)
+    q.io.inp.bits := (~enq.bits).asTypeOf(q.io.inp.bits)
     enq.ready := q.io.inp.ready
     q.io.out
   }

--- a/chisel/designutils/src/main/scala/DecoupledStage.scala
+++ b/chisel/designutils/src/main/scala/DecoupledStage.scala
@@ -11,7 +11,7 @@ class DecoupledStage[T <: Data](gen: T) extends Module {
     val out = Decoupled( gen )
   })
 
-  val out_valid = Reg( init=Bool(false) ) 
+  val out_valid = RegInit( init=false.B )
   val out_bits = Reg( gen )
 
   io.out.valid := out_valid
@@ -39,7 +39,7 @@ object DecoupledStageInv {
   def apply[T <: Data](enq: DecoupledIO[T]): DecoupledIO[T]  = {
     val q = Module(new DecoupledStage(enq.bits.cloneType))
     q.io.inp.valid := enq.valid // not using <> so that override is allowed
-    q.io.inp.bits := q.io.inp.bits.fromBits(~enq.bits.asUInt)
+    q.io.inp.bits := (~enq.bits.asUInt).asTypeOf(q.io.inp.bits)
     enq.ready := q.io.inp.ready
     q.io.out
   }

--- a/chisel/designutils/src/main/scala/DelayModel.scala
+++ b/chisel/designutils/src/main/scala/DelayModel.scala
@@ -19,7 +19,7 @@ class DelayModel[T <: Data] (gen : T, lat: Int, ii : Int) extends Module {
   when(io.in.fire) {
     iiCnt := (ii - 1).U
   }.otherwise {
-    when(iiCnt != 0.U) {
+    when(iiCnt =/= 0.U) {
       iiCnt := iiCnt - 1.U
     }
   }
@@ -41,4 +41,3 @@ object DelayModel {
     dm.io.out
   }
 }
-

--- a/chisel/reporters/src/main/scala/ReportTiming.scala
+++ b/chisel/reporters/src/main/scala/ReportTiming.scala
@@ -153,23 +153,23 @@ class ReportTiming( val area_timing : Boolean = false,
         depGraph.addVertex(LogicNode(mod.name, name))
       case mem : DefMemory =>
         val nm = mem.name
-//        
-// Seems like we want this: 
+//
+// Seems like we want this:
 //    rType: clk, en, addr, data
 //      readLatency = 0
-//        en -> data 
+//        en -> data
 //        addr -> data
 //      readLatency > 0
 //        en -> clk
 //        addr -> clk
 //        clk -> data
 //
-//    wType: clk, en, addr, data, mask  
+//    wType: clk, en, addr, data, mask
 //      writeLatency > 0
-//        en -> clk   
-//        addr -> clk   
-//        data -> clk   
-//        mask -> clk   
+//        en -> clk
+//        addr -> clk
+//        data -> clk
+//        mask -> clk
 //
 //    rwType: clk, en, addr, rdata, wmode, wdata, wmask
 //
@@ -236,7 +236,7 @@ class ReportTiming( val area_timing : Boolean = false,
 
     mod match {
       case m : Module => onStmt(m.body)
-      case m : ExtModule => 
+      case m : ExtModule =>
     }
   }
 
@@ -263,7 +263,7 @@ class ReportTiming( val area_timing : Boolean = false,
         val nodePS = LogicNode( modName, s"${name}#ps")
         val nodeNS = LogicNode( modName, s"${name}#ns")
         regs(node) = (nodePS,nodeNS)
-      case _ => 
+      case _ =>
     }
     s
   }
@@ -274,7 +274,7 @@ class ReportTiming( val area_timing : Boolean = false,
     s map allMems( mems, modName)
     s match {
       case mem : DefMemory => mems += mem
-      case _ => 
+      case _ =>
     }
     s
   }
@@ -302,11 +302,11 @@ class ReportTiming( val area_timing : Boolean = false,
 
       def inSignals( inp : Seq[Expression]) : List[(LogicNode,Int)] =
         inp.toList flatMap {
-          case ref@WRef( nm, tpe, knd, gnrd) => 
+          case ref@WRef( nm, tpe, knd, gnrd) =>
             val rhsNode = LogicNode( m.name, ref)
             val rhsNode0 = if ( regs.contains( rhsNode)) regs(rhsNode)._1 else rhsNode
             List((rhsNode0,extractWidth(tpe)))
-          case sub@WSubField( ref, nm, tpe, gnrd) => 
+          case sub@WSubField( ref, nm, tpe, gnrd) =>
             val rhsNode = LogicNode( m.name, sub)
             val rhsNode0 = if ( regs.contains( rhsNode)) regs(rhsNode)._1 else rhsNode
             List((rhsNode0,extractWidth(tpe)))
@@ -356,7 +356,7 @@ class ReportTiming( val area_timing : Boolean = false,
               println( s"constructTimingArcs: DefNode Not Yet Implemented: ${rhs}")
               ("nyi",List(), AreaNone)
           }
-          
+
           val widths = (lstOfLsts.map { lst =>
             lst.map( _._2).mkString( "(", ",", ")")
           }).mkString( "(", ",", ")")
@@ -399,7 +399,7 @@ class ReportTiming( val area_timing : Boolean = false,
                   0
                 else
                   1
-              case "validif" => 0 
+              case "validif" => 0
               case "copy" => 0
               case "literal" => 0
               case "eq" | "neq" | "and" | "or" | "xor" | "xnor" =>
@@ -410,7 +410,7 @@ class ReportTiming( val area_timing : Boolean = false,
                   chisel3.util.log2Floor( lstOfLsts.head.head._2)
                 else
                   chisel3.util.log2Floor( lstOfLsts.head.head._2) + 1
-              case _ => 
+              case _ =>
                 println(s"Unknown primitive ${o}. Assign delay to 1")
                 1
             }
@@ -528,7 +528,7 @@ class ReportTiming( val area_timing : Boolean = false,
         val header = JsObject( "delay" -> JsNumber( arrivals(v).time.get),
           "source" -> JsString( trc.head),
           "sink" -> JsString( v))
-        
+
         val trace = mutable.ArrayBuffer[JsObject]()
         for { v <- trc} {
           val a = arrivals(v)
@@ -566,7 +566,7 @@ class ReportTiming( val area_timing : Boolean = false,
         val header = JsObject( "delay" -> JsNumber( requireds(u).time.get),
           "source" -> JsString( u),
           "sink" -> JsString( trc.head))
-        
+
         val trace = mutable.ArrayBuffer[JsObject]()
         for { u <- trc} {
           val r = requireds(u)
@@ -622,7 +622,7 @@ class ReportTiming( val area_timing : Boolean = false,
     val topoOrder = reverseDepGraph.linearize
     val arrivals = mutable.Map.empty[LogicNode,Arrival]
     aMap(m.name) = arrivals
-   
+
     def assignArrivals : Unit =
       for { v <- topoOrder} {
         for { u <- depGraph.getEdges( v)
@@ -725,7 +725,7 @@ class ReportTiming( val area_timing : Boolean = false,
         val header = JsObject( "delay" -> JsNumber( arrivals(v).time.get),
           "source" -> JsString( trc.head),
           "sink" -> JsString( v))
-        
+
         val trace = mutable.ArrayBuffer[JsObject]()
         for { v <- trc} {
           val a = arrivals(v)
@@ -792,7 +792,7 @@ class ReportTiming( val area_timing : Boolean = false,
 // collect PIs
     val pis = mutable.ArrayBuffer.empty[String]
     val pos = mutable.ArrayBuffer.empty[String]
-    m.ports.foreach {
+    m.ports.foreach { x => (x: @unchecked) match {
       case Port( _, name, Input, _: GroundType) => pis += name
       case Port( _, name, Output, _: GroundType) => pos += name
       case Port( _, name, pt, g) =>
@@ -1206,7 +1206,7 @@ class ReportTiming( val area_timing : Boolean = false,
             val fileContents = scala.io.Source.fromFile( "public/index.html").getLines.mkString("\n")
             Results.Ok( fileContents).as( "text/html")
           } catch {
-            case e : java.io.FileNotFoundException => 
+            case e : java.io.FileNotFoundException =>
               Results.NotFound
           }
         }
@@ -1215,7 +1215,7 @@ class ReportTiming( val area_timing : Boolean = false,
             val fileContents = scala.io.Source.fromFile( s"public/javascript/$file").getLines.mkString("\n")
             Results.Ok( fileContents).as( "text/javascript")
           } catch {
-            case e : java.io.FileNotFoundException => 
+            case e : java.io.FileNotFoundException =>
               Results.NotFound
           }
         }
@@ -1224,7 +1224,7 @@ class ReportTiming( val area_timing : Boolean = false,
             val fileContents = scala.io.Source.fromFile( s"public/css/$file").getLines.mkString("\n")
             Results.Ok( fileContents).as( "text/css")
           } catch {
-            case e : java.io.FileNotFoundException => 
+            case e : java.io.FileNotFoundException =>
               Results.NotFound
           }
         }

--- a/chisel/reporters/src/main/scala/ReportTiming.scala
+++ b/chisel/reporters/src/main/scala/ReportTiming.scala
@@ -792,7 +792,7 @@ class ReportTiming( val area_timing : Boolean = false,
 // collect PIs
     val pis = mutable.ArrayBuffer.empty[String]
     val pos = mutable.ArrayBuffer.empty[String]
-    m.ports.foreach { x => (x: @unchecked) match {
+    m.ports.foreach {
       case Port( _, name, Input, _: GroundType) => pis += name
       case Port( _, name, Output, _: GroundType) => pos += name
       case Port( _, name, pt, g) =>

--- a/chisel/testutil/src/test/scala/TestSlowAdder.scala
+++ b/chisel/testutil/src/test/scala/TestSlowAdder.scala
@@ -18,7 +18,7 @@ class SlowDecoupledAdderOut extends Bundle {
 class SlowDecoupledAdder extends Module {
   val delay_value = 10
   val io = IO(new Bundle {
-    val in  = Decoupled(new SlowDecoupledAdderIn).flip()
+    val in  = Flipped(Decoupled(new SlowDecoupledAdderIn))
     val out = Decoupled(new SlowDecoupledAdderOut)
   })
   val busy    = RegInit(false.B)

--- a/chisel/vectoradd/src/main/scala/Arbiter.scala
+++ b/chisel/vectoradd/src/main/scala/Arbiter.scala
@@ -15,7 +15,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
   * @param gen data type
   * @param n number of inputs
   */
-class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
+class ArbiterIO[T <: Data](private val gen: T, val n: Int) extends Bundle {
   val in  = Flipped(Vec(n, Decoupled(gen)))
   val out = Decoupled(gen)
   val chosen = Output(UInt(log2Ceil(n).W))

--- a/chisel/vectoradd/src/main/scala/VectorAdd.scala
+++ b/chisel/vectoradd/src/main/scala/VectorAdd.scala
@@ -28,9 +28,8 @@ class VecAddNoConfigIO[T <: UInt](val gen : T, val vecLen : Int)(implicit params
     val mem_rd_resp  = Flipped(Decoupled( new MemRdResp))
     val mem_wr_req  = Decoupled( new MemWrReq)
     val mem_wr_resp  = Flipped(Decoupled( new MemWrResp))
-    val cnt_computed = Output(UInt(Int.MaxValue).cloneType)
+    val cnt_computed = Output(chiselTypeOf(Int.MaxValue.U))
   })
-
 }
 class VecAddNoConfig[T <: UInt](gen : T, vecLen : Int)(implicit params : AccParams) extends VecAddNoConfigIO(gen, vecLen){
   val va = Module(new SDFActor(2,1) {
@@ -41,7 +40,7 @@ class VecAddNoConfig[T <: UInt](gen : T, vecLen : Int)(implicit params : AccPara
     })
     
     override def func = {
-      io.out.bits := Vec.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
     }
   })
   val accin1 = Module (new AccIn(32))

--- a/chisel/vectoradd/src/main/scala/VectorAdd.scala
+++ b/chisel/vectoradd/src/main/scala/VectorAdd.scala
@@ -40,7 +40,7 @@ class VecAddNoConfig[T <: UInt](gen : T, vecLen : Int)(implicit params : AccPara
     })
     
     override def func = {
-      io.out.bits := VecInit.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) }
+      io.out.bits := VecInit(Seq.tabulate(vecLen) {i => io.in1.bits(i) + io.in2.bits(i) })
     }
   })
   val accin1 = Module (new AccIn(32))

--- a/chisel/vectoradd/src/test/scala/VectorAddTest.scala
+++ b/chisel/vectoradd/src/test/scala/VectorAddTest.scala
@@ -82,7 +82,7 @@ class VecAddNoConfigTb[T <: UInt](val dut_factory : ()=>VecAddNoConfigIO[T])(imp
     val mem_probe = Input((memSize-1).U.cloneType)
     val mem_monitor = Output(UInt(params.CacheLineWidth.W))
     val mem_perf_monitor = Output(new MockMemoryPerfCounters)
-    val cnt_computed = Output(UInt(Int.MaxValue).cloneType)
+    val cnt_computed = Output(chiselTypeOf(Int.MaxValue.U))
   })
 
   val mem = Module(new MockMemory(memSize,Some(MemInit.init_func), 100))


### PR DESCRIPTION
Changes:
+ != to =/=
+ Wire(init=x) to WireInit(init=x)
+ RegInit(Vec.fill()) to RegInit(VecInit(Seq.fill()))
+ type.fromBits(data) to data.asTypeOf(type)
+ Decoupled().flip() to Flipped(Decoupled())



There are a few non-chisel (mvc & firrtl) deprecations and pattern matching related warnings but those are left untouched. I might check pattern matching warnings later